### PR TITLE
Changed GLTFast to Unity's internal package

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "changelogUrl": "https://github.com/avatarsdk/metaperson-loader-unity/blob/main/CHANGELOG.md",
   "licensesUrl": "https://github.com/avatarsdk/metaperson-loader-unity/blob/main/LICENSE.md",
   "dependencies": {
-    "com.atteneder.gltfast": "5.0.4"
+    "com.unity.cloud.gltfast": "6.0.1"
  },
  "keywords": [
     "avatar",


### PR DESCRIPTION
Unity has their own hosted GLTFast package.
This one is easier to integrate into the package manager, since you can check for updates within the editor. Importing the Metaperson Loader with the old code gives an error in 2022.3.13f1, this fixes the error as well